### PR TITLE
Added low freq polling mode for energy efficiency

### DIFF
--- a/NoAdsSpotify.sh
+++ b/NoAdsSpotify.sh
@@ -180,7 +180,12 @@ while :
 
         fi
 
-        # Wait before check again
+		if [[ $* == *--low-freq-polling* ]]; then
+			# quizes Spotify to know how long is left on this track
+			TRACK_LENGTH=$(($(osascript -e 'tell application "Spotify" to duration of current track')/1000))
+			TRACK_POS=$(osascript -e 'tell application "Spotify" to player position')
+			INTERVAL_CHECK_TIME_SEC=$(echo $TRACK_LENGTH - $TRACK_POS + 0.5 | bc -l)
+		fi
         sleep $INTERVAL_CHECK_TIME_SEC
     done
 

--- a/NoAdsSpotify.sh
+++ b/NoAdsSpotify.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-CURRENT_VER=23
+CURRENT_VER=24
 
 set -e
 

--- a/NoAdsSpotify.sh
+++ b/NoAdsSpotify.sh
@@ -181,11 +181,12 @@ while :
         fi
 
 		if [[ $* == *--low-freq-polling* ]]; then
-			# quizes Spotify to know how long is left on this track
-			TRACK_LENGTH=$(($(osascript -e 'tell application "Spotify" to duration of current track')/1000))
+			# quizzes Spotify to know how long is left on this track
+			TRACK_LENGTH=$(osascript -e 'tell application "Spotify" to duration of current track')
 			TRACK_POS=$(osascript -e 'tell application "Spotify" to player position')
-			INTERVAL_CHECK_TIME_SEC=$(echo $TRACK_LENGTH - $TRACK_POS + 0.5 | bc -l)
+			INTERVAL_CHECK_TIME_SEC=$(echo $TRACK_LENGTH/1000 - $TRACK_POS + 0.5 | bc -l)
 		fi
+		# Wait before check again
         sleep $INTERVAL_CHECK_TIME_SEC
     done
 


### PR DESCRIPTION
Adding a mode (controlled by the --low-freq-polling flag) to calculate the time to sleep in the main loop from the time left in track:
- this aims at increasing the battery life on laptops
- it only works if you listen to a playlist without jumping tracks

Feel free to rename my variables, also a ceiling value on the sleep, to a minute ish, could be a better UX (so as to avoid hours long pocast to set a too long sleep).